### PR TITLE
Fixed reference to zepto.js.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
 </footer>
 
 <script>
-document.write('<script src=js/vendor/' +
+document.write('<script src=deps/foundation/' +
 ('__proto__' in {} ? 'zepto' : 'jquery') +
 '.js><\/script>')
 </script>


### PR DESCRIPTION
The website used to emit the error "'/ras_site/js/vendor/zepto.js' not found". I changed a reference to zepto.js so that is is found. I'm not actually sure what it did (the website seemed to work fine before), but everything seems hunky-dory now.

